### PR TITLE
It complies now :100:

### DIFF
--- a/LED Code/Head/Auto_LEDS/soundDefinitions.h
+++ b/LED Code/Head/Auto_LEDS/soundDefinitions.h
@@ -16,15 +16,7 @@ SdReader card;
 FatVolume vol;
 FatReader root;
 FatReader file;
-
-void playcomplete(char *name) {
-  //call out helper to find and play this name
-  playfile(name);
-  while (wave.isplaying) {
-    //do nothing  
-  }
-    //now done playing
-}
+WaveHC wave;
 
 void playfile(char *name) {
   if (wave.isplaying) {
@@ -32,14 +24,23 @@ void playfile(char *name) {
       wave.stop();
   }
   //look in root directory and open the file
-  if (!f.open(root, name)) {
+  if (!file.open(root, name)) {
     putstring("Couldn't Open File"); Serial.print(name); return;
   }
-  if (!wave.create(f)) {
+  if (!wave.create(file)) {
     putstring_nl("Not a valid WAV"); return;
   }
 
   wave.play();
+}
+
+void playcomplete(const char *name) {
+  //call out helper to find and play this name
+  playfile(name);
+  while (wave.isplaying) {
+    //do nothing  
+  }
+    //now done playing
 }
 
 int button1 = 1;


### PR DESCRIPTION
So there were a few things going on here:

1.  The issue preventing compilation was in the soundDefinitions.h file. Generally, it is best practice to NOT define methods in C/C++ header files as headers only serve as an external reference to other classes and the compiler. Functionally it doesn't really matter and will compile fine, but if you were to make this a library and distribute it to other people, a bloated header file is a big no-no because it hurts compilation performance, static analysis, and index creation performance.

2. Another side effect of defining everything in a header file is that you don't have a header to guide the compiler. The C/C++ compiler reads top to bottom, and the error regarding an undefined function was because the functions were defined out of order. Usually, the compiler reads the header to understand what methods are available, then it reads the main file (.c, .cpp, .m, .ino or whatever) to implement these methods. This way, it knows that playfile(char *name) exists regardless of where it is actually defined in the main file. Without a header, you can only call methods which are defined higher up in the file, I simply moved playcomplete after playfile and this error resolved.

3. The symbols `wave` and `f` were not defined in your code. I googled the file to see if you copied from somewhere else and located [https://github.com/BleepLabs/Blues-Exploder/blob/master/wav_F/wav_F.ino](url). There, f was a FatReader and wave was a WaveHC, I noticed that you had already defined a FatReader called `file` so I switched it over, then I defined a new WaveHC called `wave`.

4. Last but not least, the compiler was bitching about having to convert string literals to the type char *. This is because in C/C++ you can't change string literals at runtime if you use the primitive type. This is because string literals are inherently type of const char *. Basically, the compiler creates a char const * on the stack every time you define a string literal, you cannot remove the const part, although TECHNICALLY you can force it to the type char * because they are the same size in memory. The problem comes if you try and mutate this char * in runtime, because for all the compiler cares, it is type char *, but when you dereference it to change it, the system will throw a fault because you are actually trying to mutate a const. To combat this, you can use the code snippet below. My guess is that the library call never really mutates the string, but it only accepts type char *, not const char * so the whoever wrote it was lazy and just force downcasted, causing the warning but not the error (introduced in C++ 2003, this is highly depreciated but whatever it builds lol).


char name[] = "Yooo"; //Defines an array of chars with length of 5 (4 char + null terminator). Because of how C/C++ handles arrays, the resultant type is char *
name[2] = 'g'; //Mutate the 3rd char to 'g'
cout<<name; //Prints out "Yogo"


char *name = "Yooo"; //Defines a const char * string literal "Yooo" on the stack.
name[2] = 'g'; //Hard crash because const types are not mutable.
cout<<name; //Never reached
